### PR TITLE
Include einops in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
   url = 'https://github.com/lucidrains/local-attention',
   keywords = ['transformers', 'attention', 'artificial intelligence'],
   install_requires=[
-      'torch'
+      'torch', 'einops'
   ],
   classifiers=[
       'Development Status :: 4 - Beta',


### PR DESCRIPTION
After recent updates, the package depends on `einops` [here](https://github.com/lucidrains/local-attention/blob/master/local_attention/rotary.py#L3) but doesn't include it as a requirement